### PR TITLE
Fix missing app icons for absolute Icon= paths (e.g. Zen Browser)

### DIFF
--- a/src/info/process.rs
+++ b/src/info/process.rs
@@ -417,7 +417,11 @@ impl ItemInterface<ProcessCategory> for ProcessItem {
                     .and_then(|x| x.icon.as_ref())
                     .map(|x| x.as_str())
                     .unwrap_or("application-x-executable");
-                Some(widget::icon::from_name(icon).size(24).icon())
+                if Path::new(icon).is_absolute() {
+                    Some(widget::icon::from_path(icon.into()).icon().size(24))
+                } else {
+                    Some(widget::icon::from_name(icon).size(24).icon())
+                }
             }
             _ => None,
         }


### PR DESCRIPTION

<img width="2726" height="1483" alt="image" src="https://github.com/user-attachments/assets/de958710-8847-419f-b0e7-0522b5023841" />

____
- [x] I have disclosed use of any AI generated code in my commit messages.
  - If you are using an LLM, and do not fully understand the changes it is making to the code base, do not create a PR.
  - In our experience, AI generated code often results in overly complex code that lacks enough context for a proper fix or feature inclusion. This results in considerably longer code reviews. Due to this, AI authored or partially authored PRs may be closed without comment.
- [x] I understand these changes in full and will be able to respond to review comments.
- [x] My change is accurately described in the commit message.
- [x] My contribution is tested and working as described.
- [x] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.

