### PR TITLE
feat: Disambiguate process and app search.

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -286,6 +286,7 @@ pub enum Message {
     Graph(GraphItem),
     LaunchUrl(String),
     NavPage(NavPage),
+    AppSearch(String),
     ProcessSearch(String),
     ProcessSort(ProcessCategory),
     ScrollHeader(Viewport),
@@ -371,6 +372,7 @@ pub struct App {
     nav_model: segmented_button::SingleSelectModel,
     processes: Vec<ProcessItem>,
     process_content: iced::widget::list::Content<ProcessItem>,
+    app_search: (String, Option<Regex>),
     process_search: (String, Option<Regex>),
     process_sort: (ProcessCategory, bool),
     scroll_header_id: widget::Id,
@@ -409,10 +411,19 @@ impl App {
             }
         });
 
+        let search = if matches!(
+            self.nav_model.active_data::<NavPage>(),
+            Some(NavPage::Applications)
+        ) {
+            &self.app_search
+        } else {
+            &self.process_search
+        };
+
         let mut i = 0;
         for item in list.iter() {
-            if let Some(regex) = &self.process_search.1 {
-                if !item.matches(&regex) {
+            if let Some(regex) = &search.1 {
+                if !item.matches(regex) {
                     continue;
                 }
             }
@@ -1197,6 +1208,7 @@ impl Application for App {
             nav_model: nav_model.build(),
             processes: Vec::new(),
             process_content: iced::widget::list::Content::new(),
+            app_search: (String::new(), None),
             process_search: (String::new(), None),
             process_sort: (ProcessCategory::default(), false),
             scroll_header_id: widget::Id::unique(),
@@ -1227,7 +1239,11 @@ impl Application for App {
         if self.selected.take().is_some() {
             return Task::none();
         }
-        if !self.process_search.0.is_empty() || self.process_search.1.is_some() {
+        if matches!(self.nav_model.active_data::<NavPage>(), Some(NavPage::Applications)) {
+            if !self.app_search.0.is_empty() || self.app_search.1.is_some() {
+                return self.update(Message::AppSearch(String::new()));
+            }
+        } else if !self.process_search.0.is_empty() || self.process_search.1.is_some() {
             return self.update(Message::ProcessSearch(String::new()));
         }
         Task::none()
@@ -1355,6 +1371,18 @@ impl Application for App {
                     self.selected = None;
                     self.update_snapshot();
                 }
+            }
+            Message::AppSearch(search) => {
+                let regex_opt = if !search.is_empty() {
+                    RegexBuilder::new(&regex::escape(&search))
+                        .case_insensitive(true)
+                        .build()
+                        .ok()
+                } else {
+                    None
+                };
+                self.app_search = (search, regex_opt);
+                self.update_snapshot();
             }
             Message::ProcessSearch(search) => {
                 let regex_opt = if !search.is_empty() {
@@ -1680,12 +1708,28 @@ impl Application for App {
                 };
             }
             (NavPage::Applications | NavPage::Processes, _) => {
+                let (search_value, clear_message, input_message): (
+                    &String,
+                    Message,
+                    fn(String) -> Message,
+                ) = match nav_page {
+                    NavPage::Applications => (
+                        &self.app_search.0,
+                        Message::AppSearch(String::new()),
+                        Message::AppSearch as fn(String) -> Message,
+                    ),
+                    _ => (
+                        &self.process_search.0,
+                        Message::ProcessSearch(String::new()),
+                        Message::ProcessSearch as fn(String) -> Message,
+                    ),
+                };
                 page_header = page_header
                     .push(
                         widget::container(
-                            widget::search_input(fl!("search-processes"), &self.process_search.0)
-                                .on_clear(Message::ProcessSearch(String::new()))
-                                .on_input(Message::ProcessSearch)
+                            widget::search_input(fl!("search-processes"), search_value)
+                                .on_clear(clear_message)
+                                .on_input(input_message)
                                 .width(360.0),
                         )
                         .align_x(Alignment::Center)


### PR DESCRIPTION
- [X] I have disclosed use of any AI generated code in my commit messages.
  - If you are using an LLM, and do not fully understand the changes it is making to the code base, do not create a PR.
  - In our experience, AI generated code often results in overly complex code that lacks enough context for a proper fix or feature inclusion. This results in considerably longer code reviews. Due to this, AI authored or partially authored PRs may be closed without comment.
- [X] I understand these changes in full and will be able to respond to review comments.
- [X] My change is accurately described in the commit message.
- [X] My contribution is tested and working as described.
- [X] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.

fixes #96 
## Why?
The real reason why I want this is if I have typed something like 'xdg' to search in processes when I will navigate to Applications i am going to not even see anything due to not have anything from Apps matching this regex which is pretty common. So i will have to delete the search query to have the list of Apps shown which I might not even had to do that as I usually do not have many Applications installed and would probably not even search for Apps. Demostration: 

https://github.com/user-attachments/assets/ae22a65a-fa3a-42c5-ba31-61eed946c5af

