### PR TITLE
feat(disks): show disk utilization graphs

### DIFF
--- a/i18n/en/cosmic_monitor.ftl
+++ b/i18n/en/cosmic_monitor.ftl
@@ -55,8 +55,10 @@ vram = VRAM
 
 ## Disk
 all-disks = All disks
+disk-utilization = Disk utilization
 mount-path = Mount path
 reading = Reading
+throughput = Throughput
 writing = Writing
 
 ## Network

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -26,6 +26,7 @@ pub enum GraphKind<'a> {
     Swap,
     Gpu(GpuId, ProcGraphKind),
     GpuVram(GpuId),
+    DiskUtilization,
     DiskRead(&'a str),
     DiskWrite(&'a str),
     DiskTotal,
@@ -41,7 +42,8 @@ impl<'a> GraphKind<'a> {
             | GraphKind::Memory
             | GraphKind::Swap
             | GraphKind::Gpu(_, ProcGraphKind::Utilization)
-            | GraphKind::GpuVram(_) => {
+            | GraphKind::GpuVram(_)
+            | GraphKind::DiskUtilization => {
                 format!("{:.0}%", value)
             }
             GraphKind::Cpu(ProcGraphKind::Frequency)
@@ -135,7 +137,8 @@ impl<'a> canvas::Program<Message, Theme, Renderer> for Graph<'a> {
             | GraphKind::Memory
             | GraphKind::Swap
             | GraphKind::Gpu(_, ProcGraphKind::Utilization)
-            | GraphKind::GpuVram(_) => 100.0,
+            | GraphKind::GpuVram(_)
+            | GraphKind::DiskUtilization => 100.0,
             _ => {
                 let mut max = 0.0;
                 for graph_item in self.history.iter() {

--- a/src/info/disk.rs
+++ b/src/info/disk.rs
@@ -10,7 +10,23 @@ pub struct DiskItem {
     pub total: u64,
     pub read: f64,
     pub write: f64,
+    pub utilization: f32,
     pub temp: Option<f32>,
+}
+
+pub fn disk_utilization(busy: Duration, elapsed: Duration) -> f32 {
+    if elapsed.is_zero() {
+        return 0.0;
+    }
+
+    (100.0 * busy.as_secs_f32() / elapsed.as_secs_f32()).min(100.0)
+}
+
+pub fn total_disk_utilization(disks: &[DiskItem]) -> f32 {
+    disks
+        .iter()
+        .map(|disk| disk.utilization)
+        .fold(0.0, f32::max)
 }
 
 impl DiskItem {
@@ -23,6 +39,7 @@ impl DiskItem {
             total: disk.total_space(),
             read: (usage.read_bytes as f64) / refresh.as_secs_f64(),
             write: (usage.written_bytes as f64) / refresh.as_secs_f64(),
+            utilization: 0.0,
             temp: None,
         }
     }

--- a/src/info/mod.rs
+++ b/src/info/mod.rs
@@ -135,6 +135,10 @@ impl GraphItem {
         total
     }
 
+    pub fn total_disk_utilization(&self) -> f32 {
+        total_disk_utilization(&self.disks)
+    }
+
     pub fn total_network_io(&self) -> (f64, f64) {
         let mut total = (0.0, 0.0);
         for network in self.networks.iter() {
@@ -194,6 +198,7 @@ impl GraphItem {
                 }
                 total
             }
+            GraphKind::DiskUtilization => self.total_disk_utilization(),
             GraphKind::DiskRead(disk_name) => {
                 let mut total = 0.0;
                 for disk in self.disks.iter().filter(|x| x.name == disk_name) {

--- a/src/info/platform/linux/mod.rs
+++ b/src/info/platform/linux/mod.rs
@@ -7,7 +7,7 @@ use std::{
     collections::HashMap,
     fs,
     path::{Path, PathBuf},
-    sync::Arc,
+    sync::{Arc, Mutex},
     time::{Duration, Instant},
 };
 use sysinfo::{Components, Disk, Pid, Process, System};
@@ -60,6 +60,21 @@ fn resolve_to_physical(name: &str) -> Option<PathBuf> {
     }
 
     physical
+}
+
+fn disk_busy_time(stats: &str) -> Option<Duration> {
+    stats
+        .split_whitespace()
+        .nth(9)?
+        .parse()
+        .ok()
+        .map(Duration::from_millis)
+}
+
+struct DiskActivity {
+    busy: Duration,
+    sampled_at: Instant,
+    utilization: f32,
 }
 
 struct LinuxProcess {
@@ -125,6 +140,7 @@ impl LinuxProcess {
 pub struct LinuxPlatform {
     amdgpu_ids: HashMap<(u16, u8), String>,
     app_entries: Vec<Arc<AppEntry>>,
+    disk_activity: Mutex<HashMap<PathBuf, DiskActivity>>,
     gpu_energies: HashMap<GpuId, (Instant, u64)>,
     gpu_items: Vec<GpuItem>,
     nvml: Box<dyn Platform>,
@@ -191,6 +207,7 @@ impl LinuxPlatform {
         Self {
             amdgpu_ids,
             app_entries,
+            disk_activity: Mutex::new(HashMap::new()),
             gpu_energies: HashMap::new(),
             gpu_items: Vec::new(),
             #[cfg(feature = "nvml")]
@@ -209,6 +226,38 @@ impl LinuxPlatform {
         let dev_path = resolve_to_physical(&virt_dev_name).unwrap_or(virt_dev_path);
         let dev_name = dev_path.strip_prefix("/dev/").ok()?;
         let sys_class_path = Path::new("/sys/class/block").join(&dev_name);
+
+        if let (Some(busy), Ok(mut disk_activity)) = (
+            fs::read_to_string(sys_class_path.join("stat"))
+                .ok()
+                .and_then(|stats| disk_busy_time(&stats)),
+            self.disk_activity.lock(),
+        ) {
+            let sampled_at = Instant::now();
+            item.utilization = if let Some(previous) = disk_activity.get_mut(&sys_class_path) {
+                let elapsed = sampled_at.saturating_duration_since(previous.sampled_at);
+                // A block device can occur more than once in the mounted-filesystem list. Reuse
+                // its latest sample instead of replacing it with an effectively zero interval.
+                if elapsed >= Duration::from_millis(1) {
+                    previous.utilization =
+                        crate::info::disk_utilization(busy.saturating_sub(previous.busy), elapsed);
+                    previous.busy = busy;
+                    previous.sampled_at = sampled_at;
+                }
+                previous.utilization
+            } else {
+                disk_activity.insert(
+                    sys_class_path.clone(),
+                    DiskActivity {
+                        busy,
+                        sampled_at,
+                        utilization: 0.0,
+                    },
+                );
+                0.0
+            };
+        }
+
         let mut sys_path = fs::canonicalize(&sys_class_path).ok()?;
         // Partitions will be nested inside disk, which is inside device, which is inside subsystem
         // /sys/devices/.../nvme/nvme0/nvme0n1/nvme0n1p1

--- a/src/main.rs
+++ b/src/main.rs
@@ -823,11 +823,13 @@ impl App {
         ));
 
         let disk_io = graph_item.total_disk_io();
+        let disk_utilization = graph_item.total_disk_utilization();
         items.push(card(
-            GraphKind::DiskTotal,
+            GraphKind::DiskUtilization,
             fl!("disk"),
             String::new(),
             widget::column!(
+                widget::text::body(format!("{:.1}%", disk_utilization)),
                 widget::text::body(format!(
                     "{}/s read",
                     humansize::format_size(disk_io.0 as u64, humansize::DECIMAL),
@@ -2112,19 +2114,24 @@ impl Application for App {
                 }
             }
             (NavPage::Disk, Some(graph_item)) => {
-                let mut column = widget::column::with_capacity(1 + graph_item.disks.len())
+                let mut column = widget::column::with_capacity(2 + graph_item.disks.len())
                     .spacing(space_l)
                     .width(Length::Fill);
 
                 let all_used = graph_item.disks.iter().fold(0, |x, disk| x + disk.used);
                 let all_total = graph_item.disks.iter().fold(0, |x, disk| x + disk.total);
                 let all_io = graph_item.total_disk_io();
+                let all_utilization = graph_item.total_disk_utilization();
                 column = column.push(self.responsive_graph_top_processes(
                     ProcessCategory::DiskTotal,
                     move || {
                         widget::column!(
-                            widget::text::title4(fl!("all-disks")),
+                            widget::text::title4(fl!("disk-utilization")),
                             widget::row!(
+                                widget::column!(
+                                    widget::text::body(fl!("utilization")),
+                                    widget::text::heading(format!("{:.1}%", all_utilization))
+                                ),
                                 widget::column!(
                                     widget::text::body(fl!("capacity")),
                                     widget::text::heading(
@@ -2156,14 +2163,44 @@ impl Application for App {
                                 ),
                             )
                             .spacing(space_m),
-                            canvas(Graph::new(GraphKind::DiskTotal, &self.graph_history).legend())
-                                .height(LARGE_GRAPH_HEIGHT)
-                                .width(Length::Fill),
+                            canvas(
+                                Graph::new(GraphKind::DiskUtilization, &self.graph_history)
+                                    .legend()
+                            )
+                            .height(LARGE_GRAPH_HEIGHT)
+                            .width(Length::Fill),
                         )
                         .spacing(space_xxs)
                         .into()
                     },
                 ));
+
+                column = column.push(
+                    widget::column!(
+                        widget::text::title4(fl!("throughput")),
+                        widget::row!(
+                            widget::column!(
+                                widget::text::body(fl!("reading")),
+                                widget::text::heading(format!(
+                                    "{}/s",
+                                    humansize::format_size(all_io.0 as u64, humansize::DECIMAL)
+                                ))
+                            ),
+                            widget::column!(
+                                widget::text::body(fl!("writing")),
+                                widget::text::heading(format!(
+                                    "{}/s",
+                                    humansize::format_size(all_io.1 as u64, humansize::DECIMAL)
+                                ))
+                            ),
+                        )
+                        .spacing(space_m),
+                        canvas(Graph::new(GraphKind::DiskTotal, &self.graph_history).legend())
+                            .height(LARGE_GRAPH_HEIGHT)
+                            .width(Length::Fill),
+                    )
+                    .spacing(space_xxs),
+                );
 
                 for disk in graph_item.disks.iter() {
                     column = column.push(


### PR DESCRIPTION
Adds disk utilization to the disks overview an makes that the default graph. Disk utilization shows the percentage of time a disk is busy processing I/O, making it a better default graph than throughput because it reveals storage bottlenecks even when transfer rates are low.

- [x] I have disclosed use of any AI generated code in my commit messages.
  - If you are using an LLM, and do not fully understand the changes it is making to the code base, do not create a PR.
  - In our experience, AI generated code often results in overly complex code that lacks enough context for a proper fix or feature inclusion. This results in considerably longer code reviews. Due to this, AI authored or partially authored PRs may be closed without comment.
- [x] I understand these changes in full and will be able to respond to review comments.
- [x] My change is accurately described in the commit message.
- [x] My contribution is tested and working as described.
- [x] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.

